### PR TITLE
Add reqwest v0.13 support behind feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- Add `reqwest_013` feature flag that enables `HttpLayer` and `MetricLayer`
+  support for [reqwest](https://docs.rs/reqwest) v0.13. When enabled, `Http<S>`
+  from both `trace` and `metrics` modules implements
+  `Service<reqwest::Request, Response = reqwest::Response>` for client-side
+  middleware. Trace context is propagated into outgoing request headers.
+
 ## v0.8.0
 
 - Update [`opentelemetry`]` to v0.31.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -741,7 +741,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror",
  "tokio",
  "tonic",
@@ -1033,6 +1033,35 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -1421,6 +1450,7 @@ dependencies = [
  "http-body",
  "opentelemetry",
  "pin-project",
+ "reqwest 0.13.2",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ opentelemetry = { version = "0.31", default-features = false, features = [
   "metrics",
 ] }
 pin-project = "1"
+reqwest = { version = "0.13", optional = true, default-features = false }
 tower-layer = "0.3"
 tower-service = "0.3"
 tracing = { version = "0.1", default-features = false }
@@ -52,3 +53,4 @@ tracing-opentelemetry = { version = "0.32", default-features = false }
 [features]
 default = []
 axum = ["dep:axum"]
+reqwest_013 = ["dep:reqwest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,6 @@ tracing = { version = "0.1", default-features = false }
 tracing-opentelemetry = { version = "0.32", default-features = false }
 
 [features]
-default = ["axum", "reqwest_013"]
+default = []
 axum = ["dep:axum"]
 reqwest_013 = ["dep:reqwest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,6 @@ tracing = { version = "0.1", default-features = false }
 tracing-opentelemetry = { version = "0.32", default-features = false }
 
 [features]
-default = []
+default = ["axum", "reqwest_013"]
 axum = ["dep:axum"]
 reqwest_013 = ["dep:reqwest"]

--- a/src/metrics/http.rs
+++ b/src/metrics/http.rs
@@ -160,8 +160,8 @@ where
     }
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        let side = self.record.side;
-        let state = ResponseMetricState::new(side, &req);
+        let data = RequestMetricData::from_http(self.record.side, &req);
+        let state = ResponseMetricState::new(data);
         let record = Arc::clone(&self.record);
         let inner = self.inner.call(req);
 
@@ -198,33 +198,51 @@ where
         let this = self.project();
 
         let inner_response = ready!(this.inner.poll(cx));
-        let duration = this.state.elapsed_seconds();
 
-        this.state.push_response_attributes(&inner_response);
+        this.state
+            .push_response_attributes(inner_response.as_ref().map(|r| r.status()));
 
-        this.record
-            .request_duration
-            .record(duration, this.state.attributes());
-
-        this.record
-            .active_requests
-            .add(-1, this.state.active_requests_attributes());
-
-        if let Some(request_body_size) = this.state.request_body_size {
-            this.record
-                .request_body_size
-                .record(request_body_size, this.state.attributes());
-        }
-
-        if let Ok(response) = inner_response.as_ref() {
-            if let Some(response_size) = util::http_response_size(response) {
-                this.record
-                    .response_body_size
-                    .record(response_size, this.state.attributes());
-            }
-        }
+        let response_body_size = inner_response
+            .as_ref()
+            .ok()
+            .and_then(util::http_response_size);
+        this.state.record_metrics(this.record, response_body_size);
 
         Poll::Ready(inner_response)
+    }
+}
+
+/// Data extracted from an HTTP request used to build metric attributes.
+struct RequestMetricData<'a> {
+    method: &'a http::Method,
+    server_address: Option<&'a str>,
+    server_port: Option<u16>,
+    url_scheme: Option<&'a str>,
+    version: http::Version,
+    http_route: Option<&'a str>,
+    body_size: Option<u64>,
+}
+
+impl<'a> RequestMetricData<'a> {
+    fn from_http<B: Body>(side: MetricSide, req: &'a Request<B>) -> Self {
+        let util::HttpRequestAttributes {
+            url_scheme,
+            server_address,
+            server_port,
+        } = match side {
+            MetricSide::Client => util::HttpRequestAttributes::from_sent_request(req),
+            MetricSide::Server => util::HttpRequestAttributes::from_recv_request(req),
+        };
+
+        Self {
+            method: req.method(),
+            server_address,
+            server_port,
+            url_scheme,
+            version: req.version(),
+            http_route: util::http_route(req),
+            body_size: util::http_request_size(req),
+        }
     }
 }
 
@@ -239,75 +257,38 @@ struct ResponseMetricState {
 }
 
 impl ResponseMetricState {
-    fn new<B: Body>(side: MetricSide, req: &Request<B>) -> Self {
+    fn new(data: RequestMetricData<'_>) -> Self {
         let start = Instant::now();
-
-        let request_body_size = util::http_request_size(req);
+        let request_body_size = data.body_size;
 
         let active_requests_attributes;
         let attributes = {
             let mut attributes = vec![];
 
-            let http_method = util::http_method(req.method());
-            attributes.push(KeyValue::new("http.request.method", http_method));
+            attributes.push(KeyValue::new(
+                "http.request.method",
+                util::http_method(data.method),
+            ));
 
-            if let Some(server_address) = req.uri().host() {
+            if let Some(server_address) = data.server_address {
                 attributes.push(KeyValue::new("server.address", server_address.to_string()));
             }
-
-            if let Some(server_port) = req.uri().port_u16() {
+            if let Some(server_port) = data.server_port {
                 attributes.push(KeyValue::new("server.port", server_port as i64));
             }
-
-            match side {
-                // For client side the protocol is the URL.
-                MetricSide::Client => {
-                    let util::HttpRequestAttributes {
-                        url_scheme,
-                        server_address,
-                        server_port,
-                    } = util::HttpRequestAttributes::from_sent_request(req);
-
-                    if let Some(server_address) = server_address {
-                        attributes
-                            .push(KeyValue::new("server.address", server_address.to_string()));
-                    }
-                    if let Some(server_port) = server_port {
-                        attributes.push(KeyValue::new("server.port", server_port.to_string()));
-                    }
-                    if let Some(url_scheme) = url_scheme {
-                        attributes.push(KeyValue::new("url.scheme", url_scheme.to_string()));
-                    }
-                }
-                MetricSide::Server => {
-                    let util::HttpRequestAttributes {
-                        url_scheme,
-                        server_address,
-                        server_port,
-                    } = util::HttpRequestAttributes::from_recv_request(req);
-
-                    if let Some(server_address) = server_address {
-                        attributes
-                            .push(KeyValue::new("server.address", server_address.to_string()));
-                    }
-                    if let Some(server_port) = server_port {
-                        attributes.push(KeyValue::new("server.port", server_port.to_string()));
-                    }
-                    if let Some(url_scheme) = url_scheme {
-                        attributes.push(KeyValue::new("url.scheme", url_scheme.to_string()));
-                    }
-                }
-            };
+            if let Some(url_scheme) = data.url_scheme {
+                attributes.push(KeyValue::new("url.scheme", url_scheme.to_string()));
+            }
 
             active_requests_attributes = attributes.len();
 
             attributes.push(KeyValue::new("network.protocol.name", "http"));
 
-            if let Some(http_version) = util::http_version(req.version()) {
-                attributes.push(KeyValue::new("network.protocol.version", http_version));
+            if let Some(version) = util::http_version(data.version) {
+                attributes.push(KeyValue::new("network.protocol.version", version));
             }
 
-            if let Some(http_route) = util::http_route(req) {
+            if let Some(http_route) = data.http_route {
                 attributes.push(KeyValue::new("http.route", http_route.to_string()));
             }
 
@@ -322,15 +303,15 @@ impl ResponseMetricState {
         }
     }
 
-    fn push_response_attributes<B, E>(&mut self, res: &Result<Response<B>, E>)
+    fn push_response_attributes<E>(&mut self, res: Result<http::StatusCode, &E>)
     where
         E: Display,
     {
         match res {
-            Ok(response) => {
+            Ok(status) => {
                 self.attributes.push(KeyValue::new(
                     "http.response.status_code",
-                    response.status().as_u16() as i64,
+                    status.as_u16() as i64,
                 ));
             }
             Err(err) => {
@@ -340,9 +321,26 @@ impl ResponseMetricState {
         }
     }
 
-    /// Returns the elapsed time since the request was created in seconds.
-    fn elapsed_seconds(&self) -> f64 {
-        self.start.elapsed().as_secs_f64()
+    fn record_metrics(&self, record: &MetricsRecord, response_body_size: Option<u64>) {
+        let duration = self.start.elapsed().as_secs_f64();
+
+        record.request_duration.record(duration, self.attributes());
+
+        record
+            .active_requests
+            .add(-1, self.active_requests_attributes());
+
+        if let Some(request_body_size) = self.request_body_size {
+            record
+                .request_body_size
+                .record(request_body_size, self.attributes());
+        }
+
+        if let Some(response_size) = response_body_size {
+            record
+                .response_body_size
+                .record(response_size, self.attributes());
+        }
     }
 
     /// Return the attributes for each metric.

--- a/src/metrics/http.rs
+++ b/src/metrics/http.rs
@@ -1,5 +1,8 @@
 //! Middleware that adds metrics to a [`Service`] that handles HTTP requests.
 
+#[cfg(feature = "reqwest_013")]
+mod reqwest;
+
 use std::{
     fmt::Display,
     future::Future,

--- a/src/metrics/http/reqwest.rs
+++ b/src/metrics/http/reqwest.rs
@@ -4,15 +4,14 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},
-    time::Instant,
 };
 
-use opentelemetry::KeyValue;
 use pin_project::pin_project;
 use tower_service::Service;
 
-use super::{Http, MetricSide, MetricsRecord, ResponseMetricState};
-use crate::util;
+use crate::util::http_body_size_from_headers;
+
+use super::{Http, MetricSide, MetricsRecord, RequestMetricData, ResponseMetricState};
 
 impl<S> Service<reqwest::Request> for Http<S>
 where
@@ -32,7 +31,8 @@ where
             matches!(self.record.side, MetricSide::Client),
             "Http metrics middleware with reqwest::Request only supports client-side metrics"
         );
-        let state = reqwest_metric_state(&req);
+        let data = RequestMetricData::from_reqwest(&req);
+        let state = ResponseMetricState::new(data);
         let record = Arc::clone(&self.record);
         let inner = self.inner.call(req);
 
@@ -68,101 +68,30 @@ where
         let this = self.project();
 
         let inner_response = ready!(this.inner.poll(cx));
-        let duration = this.state.elapsed_seconds();
 
-        // Push response attributes (can't use push_response_attributes since it expects
-        // http::Response<B>).
-        match &inner_response {
-            Ok(response) => {
-                this.state.attributes.push(KeyValue::new(
-                    "http.response.status_code",
-                    response.status().as_u16() as i64,
-                ));
-            }
-            Err(err) => {
-                this.state
-                    .attributes
-                    .push(KeyValue::new("error.type", err.to_string()));
-            }
-        }
+        this.state
+            .push_response_attributes(inner_response.as_ref().map(|r| r.status()));
 
-        this.record
-            .request_duration
-            .record(duration, this.state.attributes());
-
-        this.record
-            .active_requests
-            .add(-1, this.state.active_requests_attributes());
-
-        if let Some(request_body_size) = this.state.request_body_size {
-            this.record
-                .request_body_size
-                .record(request_body_size, this.state.attributes());
-        }
-
-        if let Ok(response) = inner_response.as_ref() {
-            if let Some(response_size) = response_content_length(response) {
-                this.record
-                    .response_body_size
-                    .record(response_size, this.state.attributes());
-            }
-        }
+        let response_body_size = inner_response
+            .as_ref()
+            .ok()
+            .and_then(|r| http_body_size_from_headers(r.headers()));
+        this.state.record_metrics(this.record, response_body_size);
 
         Poll::Ready(inner_response)
     }
 }
 
-/// Build a [`ResponseMetricState`] from a reqwest client request.
-fn reqwest_metric_state(req: &reqwest::Request) -> ResponseMetricState {
-    let start = Instant::now();
-
-    let request_body_size = req
-        .headers()
-        .get("content-length")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok());
-
-    let active_requests_attributes;
-    let attributes = {
-        let mut attributes = vec![];
-
-        let http_method = util::http_method(req.method());
-        attributes.push(KeyValue::new("http.request.method", http_method));
-
-        if let Some(server_address) = req.url().host_str() {
-            attributes.push(KeyValue::new("server.address", server_address.to_string()));
+impl<'a> RequestMetricData<'a> {
+    pub(super) fn from_reqwest(req: &'a reqwest::Request) -> Self {
+        Self {
+            method: req.method(),
+            server_address: req.url().host_str(),
+            server_port: req.url().port_or_known_default(),
+            url_scheme: Some(req.url().scheme()),
+            version: req.version(),
+            http_route: None,
+            body_size: http_body_size_from_headers(req.headers()),
         }
-
-        if let Some(server_port) = req.url().port_or_known_default() {
-            attributes.push(KeyValue::new("server.port", server_port as i64));
-        }
-
-        attributes.push(KeyValue::new("url.scheme", req.url().scheme().to_string()));
-
-        active_requests_attributes = attributes.len();
-
-        attributes.push(KeyValue::new("network.protocol.name", "http"));
-
-        if let Some(http_version) = util::http_version(req.version()) {
-            attributes.push(KeyValue::new("network.protocol.version", http_version));
-        }
-
-        attributes
-    };
-
-    ResponseMetricState {
-        start,
-        request_body_size,
-        attributes,
-        active_requests_attributes,
     }
-}
-
-/// Read response body size from the `content-length` header.
-fn response_content_length(response: &reqwest::Response) -> Option<u64> {
-    response
-        .headers()
-        .get("content-length")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
 }

--- a/src/metrics/http/reqwest.rs
+++ b/src/metrics/http/reqwest.rs
@@ -1,0 +1,168 @@
+use std::{
+    fmt::Display,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{ready, Context, Poll},
+    time::Instant,
+};
+
+use opentelemetry::KeyValue;
+use pin_project::pin_project;
+use tower_service::Service;
+
+use super::{Http, MetricSide, MetricsRecord, ResponseMetricState};
+use crate::util;
+
+impl<S> Service<reqwest::Request> for Http<S>
+where
+    S: Service<reqwest::Request, Response = reqwest::Response>,
+    S::Error: Display,
+{
+    type Response = reqwest::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: reqwest::Request) -> Self::Future {
+        debug_assert!(
+            matches!(self.record.side, MetricSide::Client),
+            "Http metrics middleware with reqwest::Request only supports client-side metrics"
+        );
+        let state = reqwest_metric_state(&req);
+        let record = Arc::clone(&self.record);
+        let inner = self.inner.call(req);
+
+        record
+            .active_requests
+            .add(1, state.active_requests_attributes());
+
+        ResponseFuture {
+            inner,
+            record,
+            state,
+        }
+    }
+}
+
+/// Response future for [`Http`] metrics middleware when wrapping a reqwest service.
+#[pin_project]
+pub struct ResponseFuture<F> {
+    #[pin]
+    inner: F,
+    record: Arc<MetricsRecord>,
+    state: ResponseMetricState,
+}
+
+impl<F, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<reqwest::Response, E>>,
+    E: Display,
+{
+    type Output = Result<reqwest::Response, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        let inner_response = ready!(this.inner.poll(cx));
+        let duration = this.state.elapsed_seconds();
+
+        // Push response attributes (can't use push_response_attributes since it expects
+        // http::Response<B>).
+        match &inner_response {
+            Ok(response) => {
+                this.state.attributes.push(KeyValue::new(
+                    "http.response.status_code",
+                    response.status().as_u16() as i64,
+                ));
+            }
+            Err(err) => {
+                this.state
+                    .attributes
+                    .push(KeyValue::new("error.type", err.to_string()));
+            }
+        }
+
+        this.record
+            .request_duration
+            .record(duration, this.state.attributes());
+
+        this.record
+            .active_requests
+            .add(-1, this.state.active_requests_attributes());
+
+        if let Some(request_body_size) = this.state.request_body_size {
+            this.record
+                .request_body_size
+                .record(request_body_size, this.state.attributes());
+        }
+
+        if let Ok(response) = inner_response.as_ref() {
+            if let Some(response_size) = response_content_length(response) {
+                this.record
+                    .response_body_size
+                    .record(response_size, this.state.attributes());
+            }
+        }
+
+        Poll::Ready(inner_response)
+    }
+}
+
+/// Build a [`ResponseMetricState`] from a reqwest client request.
+fn reqwest_metric_state(req: &reqwest::Request) -> ResponseMetricState {
+    let start = Instant::now();
+
+    let request_body_size = req
+        .headers()
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok());
+
+    let active_requests_attributes;
+    let attributes = {
+        let mut attributes = vec![];
+
+        let http_method = util::http_method(req.method());
+        attributes.push(KeyValue::new("http.request.method", http_method));
+
+        if let Some(server_address) = req.url().host_str() {
+            attributes.push(KeyValue::new("server.address", server_address.to_string()));
+        }
+
+        if let Some(server_port) = req.url().port_or_known_default() {
+            attributes.push(KeyValue::new("server.port", server_port as i64));
+        }
+
+        attributes.push(KeyValue::new("url.scheme", req.url().scheme().to_string()));
+
+        active_requests_attributes = attributes.len();
+
+        attributes.push(KeyValue::new("network.protocol.name", "http"));
+
+        if let Some(http_version) = util::http_version(req.version()) {
+            attributes.push(KeyValue::new("network.protocol.version", http_version));
+        }
+
+        attributes
+    };
+
+    ResponseMetricState {
+        start,
+        request_body_size,
+        attributes,
+        active_requests_attributes,
+    }
+}
+
+/// Read response body size from the `content-length` header.
+fn response_content_length(response: &reqwest::Response) -> Option<u64> {
+    response
+        .headers()
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+}

--- a/src/trace/http.rs
+++ b/src/trace/http.rs
@@ -1,5 +1,8 @@
 //! Middleware that adds tracing to a [`Service`] that handles HTTP requests.
 
+#[cfg(feature = "reqwest_013")]
+mod reqwest;
+
 use std::{
     fmt::Display,
     future::Future,

--- a/src/trace/http.rs
+++ b/src/trace/http.rs
@@ -10,7 +10,7 @@ use std::{
     task::{ready, Context, Poll},
 };
 
-use http::{Request, Response};
+use http::{HeaderMap, Request, Response, StatusCode};
 use pin_project::pin_project;
 use tower_layer::Layer;
 use tower_service::Service;
@@ -19,7 +19,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::{
     trace::{extractor::HeaderExtractor, injector::HeaderInjector},
-    util,
+    util::{self, AnyUrl},
 };
 
 /// Describes the relationship between the [`Span`] and the service producing the span.
@@ -29,6 +29,112 @@ enum SpanKind {
     Client,
     /// The span describes the server-side handling of a request.
     Server,
+}
+
+impl SpanKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            SpanKind::Client => "client",
+            SpanKind::Server => "server",
+        }
+    }
+}
+
+/// Data extracted from an HTTP request used to build a tracing span.
+///
+/// `'r` is the lifetime of read-only data (URL, extensions).
+/// `'h` is the lifetime of the mutable headers borrow (for context injection/extraction).
+struct RequestSpanData<'r, 'h> {
+    kind: SpanKind,
+    /// Pre-computed via [`util::http_method`] — `'static`, no borrow of the request.
+    method: &'static str,
+    /// Pre-computed via [`util::http_version`] — `'static`, no borrow of the request.
+    version: Option<&'static str>,
+    /// Provides `path`, `query`, `host`, `port`, `scheme`, and `full_str` for the span.
+    url: AnyUrl<'r>,
+    /// For context injection (client) or extraction (server).
+    headers: &'h mut HeaderMap,
+    /// Server-only: `server.address` extracted from `Forwarded`/`Host` headers.
+    server_address: Option<String>,
+    /// Server-only: `server.port` extracted from `Forwarded`/`Host` headers.
+    server_port: Option<u16>,
+    /// Server-only: `url.scheme` extracted from `Forwarded`/`X-Forwarded-Proto` headers.
+    url_scheme: Option<String>,
+    /// Server-only. Borrowed from `parts.extensions` (disjoint from headers).
+    http_route: Option<&'r str>,
+    /// Server-only. Copied to avoid a lifetime on `SocketAddr`.
+    client_address: Option<std::net::SocketAddr>,
+}
+
+impl<'r, 'h> RequestSpanData<'r, 'h> {
+    /// Build from the parts of an `http::Request` acting as a **client**.
+    ///
+    /// Uses disjoint field access on [`http::request::Parts`]: `parts.uri` (shared) and
+    /// `parts.headers` (exclusive) can coexist because they are separate struct fields.
+    fn from_http_client_parts(parts: &'r mut http::request::Parts) -> Self
+    where
+        'r: 'h,
+    {
+        let method = util::http_method(&parts.method);
+        let version = util::http_version(parts.version);
+        // Borrow parts.uri specifically — disjoint from parts.headers.
+        let url = AnyUrl::Uri(&parts.uri);
+        // All borrows above are from parts.uri or 'static — disjoint from parts.headers.
+        let headers = &mut parts.headers;
+        Self {
+            kind: SpanKind::Client,
+            method,
+            version,
+            url,
+            headers,
+            server_address: None,
+            server_port: None,
+            url_scheme: None,
+            http_route: None,
+            client_address: None,
+        }
+    }
+
+    /// Build from the parts of an `http::Request` acting as a **server**.
+    ///
+    /// `server_address` and `url_scheme` are extracted from headers and immediately owned
+    /// so that `parts.headers` can then be mutably borrowed for context extraction.
+    fn from_http_server_parts(parts: &'r mut http::request::Parts) -> Self
+    where
+        'r: 'h,
+    {
+        let method = util::http_method(&parts.method);
+        let version = util::http_version(parts.version);
+        // server_address and url_scheme come from parts.headers (shared borrow).
+        // Convert to owned immediately so we can take &mut parts.headers next.
+        let (server_address, url_scheme, server_port) = {
+            let attrs = util::HttpRequestAttributes::from_recv_headers(&parts.headers);
+            (
+                attrs.server_address.map(ToOwned::to_owned),
+                attrs.url_scheme.map(ToOwned::to_owned),
+                attrs.server_port,
+            )
+            // attrs (and shared borrow of parts.headers) dropped here
+        };
+        // http_route and client_address come from parts.extensions — disjoint from headers.
+        let http_route = util::http_route_from_extensions(&parts.extensions);
+        let client_address = util::client_address_from_extensions(&parts.extensions).copied();
+        // parts.uri and parts.headers are separate fields — disjoint borrows OK.
+        let url = AnyUrl::Uri(&parts.uri);
+        let headers = &mut parts.headers;
+        Self {
+            kind: SpanKind::Server,
+            method,
+            version,
+            url,
+            headers,
+            server_address,
+            server_port,
+            url_scheme,
+            http_route,
+            client_address,
+        }
+    }
 }
 
 /// [`Layer`] that adds tracing to a [`Service`] that handles HTTP requests.
@@ -89,8 +195,16 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
-        let span = make_request_span(self.level, self.kind, &mut req);
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let (mut parts, body) = req.into_parts();
+        let span = {
+            let mut data = match self.kind {
+                SpanKind::Client => RequestSpanData::from_http_client_parts(&mut parts),
+                SpanKind::Server => RequestSpanData::from_http_server_parts(&mut parts),
+            };
+            make_request_span(self.level, &mut data)
+        };
+        let req = Request::from_parts(parts, body);
         let inner = {
             let _enter = span.enter();
             self.inner.call(req)
@@ -126,7 +240,7 @@ where
 
         match ready!(this.inner.poll(cx)) {
             Ok(response) => {
-                record_response(this.span, *this.kind, &response);
+                record_response(this.span, response.status(), response.headers());
                 Poll::Ready(Ok(response))
             }
             Err(err) => {
@@ -137,16 +251,8 @@ where
     }
 }
 
-/// String representation of span kind
-fn span_kind(kind: SpanKind) -> &'static str {
-    match kind {
-        SpanKind::Client => "client",
-        SpanKind::Server => "server",
-    }
-}
-
 /// Creates a new [`Span`] for the given request.
-fn make_request_span<B>(level: Level, kind: SpanKind, request: &mut Request<B>) -> Span {
+fn make_request_span(level: Level, data: &mut RequestSpanData<'_, '_>) -> Span {
     macro_rules! make_span {
         ($level:expr) => {{
             use tracing::field::Empty;
@@ -157,16 +263,16 @@ fn make_request_span<B>(level: Level, kind: SpanKind, request: &mut Request<B>) 
                 "client.address" = Empty,
                 "client.port" = Empty,
                 "error.message" = Empty,
-                "http.request.method" = util::http_method(request.method()),
+                "http.request.method" = data.method,
                 "http.response.status_code" = Empty,
                 "network.protocol.name" = "http",
-                "network.protocol.version" = util::http_version(request.version()),
-                "otel.kind" = span_kind(kind),
+                "network.protocol.version" = data.version,
+                "otel.kind" = data.kind.as_str(),
                 "otel.status_code" = Empty,
                 "server.address" = Empty,
                 "server.port" = Empty,
                 "url.full" = Empty,
-                "url.path" = request.uri().path(),
+                "url.path" = data.url.path(),
                 "url.query" = Empty,
                 "url.scheme" = Empty,
             )
@@ -181,70 +287,58 @@ fn make_request_span<B>(level: Level, kind: SpanKind, request: &mut Request<B>) 
         Level::TRACE => make_span!(Level::TRACE),
     };
 
-    for (header_name, header_value) in request.headers().iter() {
+    for (header_name, header_value) in data.headers.iter() {
         if let Ok(attribute_value) = header_value.to_str() {
             let attribute_name = format!("http.request.header.{}", header_name);
             span.set_attribute(attribute_name, attribute_value.to_owned());
         }
     }
 
-    if let Some(query) = request.uri().query() {
+    if let Some(query) = data.url.query() {
         span.record("url.query", query);
     }
 
-    match kind {
+    match data.kind {
         SpanKind::Client => {
-            span.record("url.full", tracing::field::display(request.uri()));
-
-            let util::HttpRequestAttributes {
-                url_scheme,
-                server_address,
-                server_port,
-            } = util::HttpRequestAttributes::from_sent_request(request);
-
-            if let Some(server_address) = server_address {
-                span.record("server.address", server_address);
+            span.record("url.full", data.url.full_str().as_ref());
+            if let Some(host) = data.url.host() {
+                span.record("server.address", host);
             }
-            if let Some(server_port) = server_port {
-                span.record("server.port", server_port);
+            if let Some(port) = data.url.port_or_default() {
+                span.record("server.port", port);
             }
-            if let Some(url_scheme) = url_scheme {
-                span.record("url.scheme", url_scheme);
+            if let Some(scheme) = data.url.scheme() {
+                span.record("url.scheme", scheme);
             }
 
             let context = span.context();
             opentelemetry::global::get_text_map_propagator(|injector| {
-                injector.inject_context(&context, &mut HeaderInjector(request.headers_mut()));
+                injector.inject_context(&context, &mut HeaderInjector(data.headers));
             });
         }
         SpanKind::Server => {
-            if let Some(http_route) = util::http_route(request) {
+            if let Some(http_route) = data.http_route {
                 span.record("http.route", http_route);
             }
-            if let Some(client_address) = util::client_address(request) {
-                let ip = client_address.ip();
-                span.record("client.address", tracing::field::display(ip));
+            if let Some(client_address) = data.client_address {
+                span.record(
+                    "client.address",
+                    tracing::field::display(client_address.ip()),
+                );
                 span.record("client.port", client_address.port());
             }
-
-            let util::HttpRequestAttributes {
-                url_scheme,
-                server_address,
-                server_port,
-            } = util::HttpRequestAttributes::from_recv_request(request);
-
-            if let Some(server_address) = server_address {
-                span.record("server.address", server_address);
+            if let Some(ref server_address) = data.server_address {
+                span.record("server.address", server_address.as_str());
             }
-            if let Some(server_port) = server_port {
+            if let Some(server_port) = data.server_port {
                 span.record("server.port", server_port);
             }
-            if let Some(url_scheme) = url_scheme {
-                span.record("url.scheme", url_scheme);
+            if let Some(ref url_scheme) = data.url_scheme {
+                span.record("url.scheme", url_scheme.as_str());
             }
 
             let context = opentelemetry::global::get_text_map_propagator(|extractor| {
-                extractor.extract(&HeaderExtractor(request.headers_mut()))
+                extractor.extract(&HeaderExtractor(data.headers))
             });
             if let Err(err) = span.set_parent(context) {
                 tracing::warn!("Failed to set parent span: {err}");
@@ -256,25 +350,17 @@ fn make_request_span<B>(level: Level, kind: SpanKind, request: &mut Request<B>) 
 }
 
 /// Records fields associated to the response.
-fn record_response<B>(span: &Span, kind: SpanKind, response: &Response<B>) {
-    span.record(
-        "http.response.status_code",
-        response.status().as_u16() as i64,
-    );
+fn record_response(span: &Span, status: StatusCode, headers: &HeaderMap) {
+    span.record("http.response.status_code", status.as_u16() as i64);
 
-    for (header_name, header_value) in response.headers().iter() {
+    for (header_name, header_value) in headers.iter() {
         if let Ok(attribute_value) = header_value.to_str() {
             let attribute_name = format!("http.response.header.{}", header_name);
             span.set_attribute(attribute_name, attribute_value.to_owned());
         }
     }
 
-    if let SpanKind::Client = kind {
-        if response.status().is_client_error() {
-            span.record("otel.status_code", "ERROR");
-        }
-    }
-    if response.status().is_server_error() {
+    if status.is_server_error() || status.is_client_error() {
         span.record("otel.status_code", "ERROR");
     }
 }

--- a/src/trace/http.rs
+++ b/src/trace/http.rs
@@ -240,7 +240,7 @@ where
 
         match ready!(this.inner.poll(cx)) {
             Ok(response) => {
-                record_response(this.span, response.status(), response.headers());
+                record_response(this.span, *this.kind, response.status(), response.headers());
                 Poll::Ready(Ok(response))
             }
             Err(err) => {
@@ -350,7 +350,7 @@ fn make_request_span(level: Level, data: &mut RequestSpanData<'_, '_>) -> Span {
 }
 
 /// Records fields associated to the response.
-fn record_response(span: &Span, status: StatusCode, headers: &HeaderMap) {
+fn record_response(span: &Span, kind: SpanKind, status: StatusCode, headers: &HeaderMap) {
     span.record("http.response.status_code", status.as_u16() as i64);
 
     for (header_name, header_value) in headers.iter() {
@@ -360,7 +360,12 @@ fn record_response(span: &Span, status: StatusCode, headers: &HeaderMap) {
         }
     }
 
-    if status.is_server_error() || status.is_client_error() {
+    if let SpanKind::Client = kind {
+        if status.is_client_error() {
+            span.record("otel.status_code", "ERROR");
+        }
+    }
+    if status.is_server_error() {
         span.record("otel.status_code", "ERROR");
     }
 }

--- a/src/trace/http/reqwest.rs
+++ b/src/trace/http/reqwest.rs
@@ -7,11 +7,45 @@ use std::{
 
 use pin_project::pin_project;
 use tower_service::Service;
-use tracing::{Level, Span};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing::Span;
 
-use super::{record_error, span_kind, Http, SpanKind};
-use crate::{trace::injector::HeaderInjector, util};
+use super::{
+    make_request_span, record_error, record_response, AnyUrl, Http, RequestSpanData, SpanKind,
+};
+use crate::util;
+
+impl<'r, 'h> RequestSpanData<'r, 'h> {
+    /// Build from a `reqwest::Request` acting as a **client**.
+    ///
+    /// Since `reqwest::Request` has no `into_parts()`, `req.url()` (shared borrow) and
+    /// `req.headers_mut()` (exclusive borrow) cannot coexist. The URL is cloned once so
+    /// that the shared borrow ends before the exclusive borrow begins. All string accessors
+    /// then borrow from the owned `url::Url` — zero further allocations.
+    pub(super) fn from_reqwest_request(kind: SpanKind, req: &'r mut reqwest::Request) -> Self
+    where
+        'r: 'h,
+    {
+        let method = util::http_method(req.method());
+        let version = util::http_version(req.version());
+        // Clone the whole URL once; all string borrows (path, host, scheme, …) come from
+        // the owned value. The shared borrow of `req` ends here, before headers_mut().
+        let url = AnyUrl::Url(req.url().clone());
+        // All shared borrows of req released. Safe to take exclusive borrow:
+        let headers = req.headers_mut();
+        Self {
+            kind,
+            method,
+            version,
+            url,
+            headers,
+            server_address: None,
+            server_port: None,
+            url_scheme: None,
+            http_route: None,
+            client_address: None,
+        }
+    }
+}
 
 impl<S> Service<reqwest::Request> for Http<S>
 where
@@ -31,7 +65,10 @@ where
             matches!(self.kind, SpanKind::Client),
             "Http middleware with reqwest::Request only supports client-side spans"
         );
-        let span = make_span(self.level, self.kind, &mut req);
+        let span = {
+            let mut data = RequestSpanData::from_reqwest_request(self.kind, &mut req);
+            make_request_span(self.level, &mut data)
+        };
         let inner = {
             let _enter = span.enter();
             self.inner.call(req)
@@ -66,7 +103,7 @@ where
 
         match ready!(this.inner.poll(cx)) {
             Ok(response) => {
-                record_response(this.span, *this.kind, &response);
+                record_response(this.span, response.status(), response.headers());
                 Poll::Ready(Ok(response))
             }
             Err(err) => {
@@ -74,90 +111,5 @@ where
                 Poll::Ready(Err(err))
             }
         }
-    }
-}
-
-fn make_span(level: Level, kind: SpanKind, request: &mut reqwest::Request) -> Span {
-    macro_rules! make_span {
-        ($level:expr) => {{
-            use tracing::field::Empty;
-
-            tracing::span!(
-                $level,
-                "HTTP",
-                "error.message" = Empty,
-                "http.request.method" = util::http_method(request.method()),
-                "http.response.status_code" = Empty,
-                "network.protocol.name" = "http",
-                "network.protocol.version" = util::http_version(request.version()),
-                "otel.kind" = span_kind(kind),
-                "otel.status_code" = Empty,
-                "server.address" = Empty,
-                "server.port" = Empty,
-                "url.full" = Empty,
-                "url.path" = request.url().path(),
-                "url.query" = Empty,
-                "url.scheme" = Empty,
-            )
-        }};
-    }
-
-    let span = match level {
-        Level::ERROR => make_span!(Level::ERROR),
-        Level::WARN => make_span!(Level::WARN),
-        Level::INFO => make_span!(Level::INFO),
-        Level::DEBUG => make_span!(Level::DEBUG),
-        Level::TRACE => make_span!(Level::TRACE),
-    };
-
-    for (header_name, header_value) in request.headers().iter() {
-        if let Ok(attribute_value) = header_value.to_str() {
-            let attribute_name = format!("http.request.header.{}", header_name);
-            span.set_attribute(attribute_name, attribute_value.to_owned());
-        }
-    }
-
-    if let Some(query) = request.url().query() {
-        span.record("url.query", query);
-    }
-
-    span.record("url.full", request.url().as_str());
-
-    if let Some(server_address) = request.url().host_str() {
-        span.record("server.address", server_address);
-    }
-    if let Some(server_port) = request.url().port_or_known_default() {
-        span.record("server.port", server_port as i64);
-    }
-    span.record("url.scheme", request.url().scheme());
-
-    let context = span.context();
-    opentelemetry::global::get_text_map_propagator(|injector| {
-        injector.inject_context(&context, &mut HeaderInjector(request.headers_mut()));
-    });
-
-    span
-}
-
-fn record_response(span: &Span, kind: SpanKind, response: &reqwest::Response) {
-    span.record(
-        "http.response.status_code",
-        response.status().as_u16() as i64,
-    );
-
-    for (header_name, header_value) in response.headers().iter() {
-        if let Ok(attribute_value) = header_value.to_str() {
-            let attribute_name = format!("http.response.header.{}", header_name);
-            span.set_attribute(attribute_name, attribute_value.to_owned());
-        }
-    }
-
-    if let SpanKind::Client = kind {
-        if response.status().is_client_error() {
-            span.record("otel.status_code", "ERROR");
-        }
-    }
-    if response.status().is_server_error() {
-        span.record("otel.status_code", "ERROR");
     }
 }

--- a/src/trace/http/reqwest.rs
+++ b/src/trace/http/reqwest.rs
@@ -103,7 +103,7 @@ where
 
         match ready!(this.inner.poll(cx)) {
             Ok(response) => {
-                record_response(this.span, response.status(), response.headers());
+                record_response(this.span, *this.kind, response.status(), response.headers());
                 Poll::Ready(Ok(response))
             }
             Err(err) => {

--- a/src/trace/http/reqwest.rs
+++ b/src/trace/http/reqwest.rs
@@ -1,0 +1,163 @@
+use std::{
+    fmt::Display,
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+use pin_project::pin_project;
+use tower_service::Service;
+use tracing::{Level, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+use super::{record_error, span_kind, Http, SpanKind};
+use crate::{trace::injector::HeaderInjector, util};
+
+impl<S> Service<reqwest::Request> for Http<S>
+where
+    S: Service<reqwest::Request, Response = reqwest::Response>,
+    S::Error: Display,
+{
+    type Response = reqwest::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: reqwest::Request) -> Self::Future {
+        debug_assert!(
+            matches!(self.kind, SpanKind::Client),
+            "Http middleware with reqwest::Request only supports client-side spans"
+        );
+        let span = make_span(self.level, self.kind, &mut req);
+        let inner = {
+            let _enter = span.enter();
+            self.inner.call(req)
+        };
+        ResponseFuture {
+            inner,
+            span,
+            kind: self.kind,
+        }
+    }
+}
+
+/// Response future for [`Http`] tracing middleware when wrapping a reqwest service.
+#[pin_project]
+pub struct ResponseFuture<F> {
+    #[pin]
+    inner: F,
+    span: Span,
+    kind: SpanKind,
+}
+
+impl<F, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<reqwest::Response, E>>,
+    E: Display,
+{
+    type Output = Result<reqwest::Response, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let _enter = this.span.enter();
+
+        match ready!(this.inner.poll(cx)) {
+            Ok(response) => {
+                record_response(this.span, *this.kind, &response);
+                Poll::Ready(Ok(response))
+            }
+            Err(err) => {
+                record_error(this.span, &err);
+                Poll::Ready(Err(err))
+            }
+        }
+    }
+}
+
+fn make_span(level: Level, kind: SpanKind, request: &mut reqwest::Request) -> Span {
+    macro_rules! make_span {
+        ($level:expr) => {{
+            use tracing::field::Empty;
+
+            tracing::span!(
+                $level,
+                "HTTP",
+                "error.message" = Empty,
+                "http.request.method" = util::http_method(request.method()),
+                "http.response.status_code" = Empty,
+                "network.protocol.name" = "http",
+                "network.protocol.version" = util::http_version(request.version()),
+                "otel.kind" = span_kind(kind),
+                "otel.status_code" = Empty,
+                "server.address" = Empty,
+                "server.port" = Empty,
+                "url.full" = Empty,
+                "url.path" = request.url().path(),
+                "url.query" = Empty,
+                "url.scheme" = Empty,
+            )
+        }};
+    }
+
+    let span = match level {
+        Level::ERROR => make_span!(Level::ERROR),
+        Level::WARN => make_span!(Level::WARN),
+        Level::INFO => make_span!(Level::INFO),
+        Level::DEBUG => make_span!(Level::DEBUG),
+        Level::TRACE => make_span!(Level::TRACE),
+    };
+
+    for (header_name, header_value) in request.headers().iter() {
+        if let Ok(attribute_value) = header_value.to_str() {
+            let attribute_name = format!("http.request.header.{}", header_name);
+            span.set_attribute(attribute_name, attribute_value.to_owned());
+        }
+    }
+
+    if let Some(query) = request.url().query() {
+        span.record("url.query", query);
+    }
+
+    span.record("url.full", request.url().as_str());
+
+    if let Some(server_address) = request.url().host_str() {
+        span.record("server.address", server_address);
+    }
+    if let Some(server_port) = request.url().port_or_known_default() {
+        span.record("server.port", server_port as i64);
+    }
+    span.record("url.scheme", request.url().scheme());
+
+    let context = span.context();
+    opentelemetry::global::get_text_map_propagator(|injector| {
+        injector.inject_context(&context, &mut HeaderInjector(request.headers_mut()));
+    });
+
+    span
+}
+
+fn record_response(span: &Span, kind: SpanKind, response: &reqwest::Response) {
+    span.record(
+        "http.response.status_code",
+        response.status().as_u16() as i64,
+    );
+
+    for (header_name, header_value) in response.headers().iter() {
+        if let Ok(attribute_value) = header_value.to_str() {
+            let attribute_name = format!("http.response.header.{}", header_name);
+            span.set_attribute(attribute_name, attribute_value.to_owned());
+        }
+    }
+
+    if let SpanKind::Client = kind {
+        if response.status().is_client_error() {
+            span.record("otel.status_code", "ERROR");
+        }
+    }
+    if response.status().is_server_error() {
+        span.record("otel.status_code", "ERROR");
+    }
+}

--- a/src/util/http.rs
+++ b/src/util/http.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{borrow::Cow, str::FromStr};
 
 use http::{Method, Request, Version};
 use http_body::Body;
@@ -39,20 +39,86 @@ pub fn http_version(version: Version) -> Option<&'static str> {
 
 /// Get the size of the HTTP request body from the `Content-Length` header.
 pub fn http_request_size<B: Body>(req: &Request<B>) -> Option<u64> {
-    req.headers()
-        .get("content-length")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse().ok())
-        .or_else(|| req.body().size_hint().exact())
+    http_body_size_from_headers(req.headers()).or_else(|| req.body().size_hint().exact())
 }
 
 /// Get the size of the HTTP response body from the `Content-Length` header.
 pub fn http_response_size<B: Body>(res: &http::Response<B>) -> Option<u64> {
-    res.headers()
+    http_body_size_from_headers(res.headers()).or_else(|| res.body().size_hint().exact())
+}
+
+pub fn http_body_size_from_headers(headers: &http::HeaderMap) -> Option<u64> {
+    headers
         .get("content-length")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.parse().ok())
-        .or_else(|| res.body().size_hint().exact())
+}
+
+/// The URL of an HTTP request, either borrowed from an `http::Uri` or cloned from a `url::Url`.
+///
+/// For `http::Request` the URI is borrowed directly (zero allocation for URL fields).
+/// For `reqwest::Request` the URL is cloned once (one allocation total, then all string
+/// accessors borrow from the owned value).
+pub(crate) enum AnyUrl<'r> {
+    Uri(&'r http::Uri),
+    #[cfg(feature = "reqwest_013")]
+    Url(reqwest::Url),
+}
+
+impl<'r> AnyUrl<'r> {
+    pub(crate) fn path(&self) -> &str {
+        match self {
+            AnyUrl::Uri(uri) => uri.path(),
+            #[cfg(feature = "reqwest_013")]
+            AnyUrl::Url(url) => url.path(),
+        }
+    }
+
+    pub(crate) fn query(&self) -> Option<&str> {
+        match self {
+            AnyUrl::Uri(uri) => uri.query(),
+            #[cfg(feature = "reqwest_013")]
+            AnyUrl::Url(url) => url.query(),
+        }
+    }
+
+    /// Returns the full URL string. For `http::Uri` this allocates once; for `url::Url`
+    /// it borrows from the owned value (zero allocation).
+    pub(crate) fn full_str(&self) -> Cow<'_, str> {
+        match self {
+            AnyUrl::Uri(uri) => Cow::Owned(uri.to_string()),
+            #[cfg(feature = "reqwest_013")]
+            AnyUrl::Url(url) => Cow::Borrowed(url.as_str()),
+        }
+    }
+
+    pub(crate) fn host(&self) -> Option<&str> {
+        match self {
+            AnyUrl::Uri(uri) => uri.host(),
+            #[cfg(feature = "reqwest_013")]
+            AnyUrl::Url(url) => url.host_str(),
+        }
+    }
+
+    pub(crate) fn port_or_default(&self) -> Option<u16> {
+        match self {
+            AnyUrl::Uri(uri) => uri.port_u16().or_else(|| match uri.scheme_str() {
+                Some("http") => Some(80),
+                Some("https") => Some(443),
+                _ => None,
+            }),
+            #[cfg(feature = "reqwest_013")]
+            AnyUrl::Url(url) => url.port_or_known_default(),
+        }
+    }
+
+    pub(crate) fn scheme(&self) -> Option<&str> {
+        match self {
+            AnyUrl::Uri(uri) => uri.scheme_str(),
+            #[cfg(feature = "reqwest_013")]
+            AnyUrl::Url(url) => Some(url.scheme()),
+        }
+    }
 }
 
 /// Parsed `Forwarded` header.
@@ -117,16 +183,18 @@ pub struct HttpRequestAttributes<'a> {
 }
 
 impl<'a> HttpRequestAttributes<'a> {
-    /// Extract HTTP request attributes from a sent request.
-    pub fn from_sent_request<B>(request: &'a Request<B>) -> Self {
-        let url_scheme = request.uri().scheme_str();
-        let server_address = request.uri().host();
-        let server_port = request.uri().port_u16().or(match url_scheme {
+    /// Extract HTTP request attributes from a URI (sent request).
+    ///
+    /// Prefer this over [`from_sent_request`] when you need to borrow only the URI
+    /// so that other parts of the request (e.g. headers) can be borrowed independently.
+    pub fn from_uri(uri: &'a http::Uri) -> Self {
+        let url_scheme = uri.scheme_str();
+        let server_address = uri.host();
+        let server_port = uri.port_u16().or(match url_scheme {
             Some("http") => Some(HTTP_DEFAULT_PORT),
             Some("https") => Some(HTTPS_DEFAULT_PORT),
             _ => None,
         });
-
         Self {
             url_scheme,
             server_address,
@@ -134,35 +202,32 @@ impl<'a> HttpRequestAttributes<'a> {
         }
     }
 
-    /// Extract HTTP request attributes from a received request.
-    pub fn from_recv_request<B>(request: &'a Request<B>) -> Self {
-        let (host, url_scheme) = request
-            .headers()
+    /// Extract HTTP request attributes from a sent request.
+    pub fn from_sent_request<B>(request: &'a Request<B>) -> Self {
+        Self::from_uri(request.uri())
+    }
+
+    /// Extract HTTP request attributes from the headers of a received request.
+    ///
+    /// Prefer this over [`from_recv_request`] when you need to borrow only the headers
+    /// so that other parts of the request (e.g. URI) can be borrowed independently.
+    pub fn from_recv_headers(headers: &'a http::HeaderMap) -> Self {
+        let (host, url_scheme) = headers
             .get(http::header::FORWARDED)
             .map(Forwarded::parse_header_value)
             .map(|Forwarded { host, proto }| (host, proto))
             .unwrap_or_default();
 
         let host = host
+            .or_else(|| headers.get(X_FORWARDED_HOST).and_then(|v| v.to_str().ok()))
             .or_else(|| {
-                request
-                    .headers()
-                    .get(X_FORWARDED_HOST)
-                    .and_then(|v| v.to_str().ok())
-            })
-            .or_else(|| {
-                request
-                    .headers()
+                headers
                     .get(http::header::HOST)
                     .and_then(|v| v.to_str().ok())
             });
 
-        let url_scheme = url_scheme.or_else(|| {
-            request
-                .headers()
-                .get(X_FORWARDED_PROTO)
-                .and_then(|v| v.to_str().ok())
-        });
+        let url_scheme =
+            url_scheme.or_else(|| headers.get(X_FORWARDED_PROTO).and_then(|v| v.to_str().ok()));
 
         let (server_address, server_port) = host
             .and_then(|host| host.split_once(':'))
@@ -182,24 +247,45 @@ impl<'a> HttpRequestAttributes<'a> {
             server_port,
         }
     }
+
+    /// Extract HTTP request attributes from a received request.
+    pub fn from_recv_request<B>(request: &'a Request<B>) -> Self {
+        Self::from_recv_headers(request.headers())
+    }
 }
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "axum")] {
-        pub fn http_route<B>(req: &http::Request<B>) -> Option<&str> {
+        pub fn http_route_from_extensions(extensions: &http::Extensions) -> Option<&str> {
             use axum::extract::MatchedPath;
-            req.extensions()
+            extensions
                 .get::<MatchedPath>()
                 .map(|matched_path| matched_path.as_str())
         }
 
-        pub fn client_address<B>(req: &http::Request<B>) -> Option<&'_ std::net::SocketAddr> {
+        pub fn client_address_from_extensions(extensions: &http::Extensions) -> Option<&std::net::SocketAddr> {
             use axum::extract::ConnectInfo;
-            req.extensions()
+            extensions
                 .get::<ConnectInfo<std::net::SocketAddr>>()
                 .map(|ConnectInfo(addr)| addr)
         }
+
+        pub fn http_route<B>(req: &http::Request<B>) -> Option<&str> {
+            http_route_from_extensions(req.extensions())
+        }
+
+        pub fn client_address<B>(req: &http::Request<B>) -> Option<&'_ std::net::SocketAddr> {
+            client_address_from_extensions(req.extensions())
+        }
     } else {
+        pub fn http_route_from_extensions(_extensions: &http::Extensions) -> Option<&str> {
+            None
+        }
+
+        pub fn client_address_from_extensions(_extensions: &http::Extensions) -> Option<&std::net::SocketAddr> {
+            None
+        }
+
         pub fn http_route<B>(_req: &http::Request<B>) -> Option<&str> {
             None
         }


### PR DESCRIPTION
This is quite big PR because I wanted to keep logic for both `http::{Request, Response}` and `reqwest::{Request, Response}` in single place as much as possible this is why I create helper structs that abstract these types when reporting traces and metrics. I hope that compiler should optimize it quite good but I didn't test it. 

Let me know if this is welcome change. 