### PR TITLE
Redact sensitive request and response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Redact sensitive request and response headers.
+
 ## 0.10.0
 
 - Update [`opentelemetry`]` to v0.32.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [".", "examples/http", "examples/grpc"]
 authors = [
   "Mattia Penati <mattia.penati@protonmail.com>",
   "Sylwester Rąpała <sylwesterrapala@outlook.com>",
+  "Stefan Kreutz <mail@skreutz.com>",
 ]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/src/trace/grpc.rs
+++ b/src/trace/grpc.rs
@@ -171,7 +171,12 @@ fn make_request_span<B>(level: Level, kind: SpanKind, request: &mut Request<B>) 
     };
 
     for (header_name, header_value) in request.headers().iter() {
-        if let Ok(attribute_value) = header_value.to_str() {
+        let attribute_value = if header_value.is_sensitive() {
+            Some("Sensitive")
+        } else {
+            header_value.to_str().ok()
+        };
+        if let Some(attribute_value) = attribute_value {
             let attribute_name = format!("rpc.grpc.request.metadata.{}", header_name);
             span.set_attribute(attribute_name, attribute_value.to_owned());
         }
@@ -240,7 +245,12 @@ fn make_request_span<B>(level: Level, kind: SpanKind, request: &mut Request<B>) 
 /// Records fields associated to the response.
 fn record_response<B>(span: &Span, response: &Response<B>) {
     for (header_name, header_value) in response.headers().iter() {
-        if let Ok(attribute_value) = header_value.to_str() {
+        let attribute_value = if header_value.is_sensitive() {
+            Some("Sensitive")
+        } else {
+            header_value.to_str().ok()
+        };
+        if let Some(attribute_value) = attribute_value {
             let attribute_name = format!("rpc.grpc.response.metadata.{}", header_name);
             span.set_attribute(attribute_name, attribute_value.to_owned());
         }

--- a/src/trace/http.rs
+++ b/src/trace/http.rs
@@ -177,7 +177,12 @@ fn make_request_span(level: Level, kind: sealed::SpanKind, request: &mut impl Ht
     };
 
     for (header_name, header_value) in data.headers.iter() {
-        if let Ok(attribute_value) = header_value.to_str() {
+        let attribute_value = if header_value.is_sensitive() {
+            Some("Sensitive")
+        } else {
+            header_value.to_str().ok()
+        };
+        if let Some(attribute_value) = attribute_value {
             let attribute_name = format!("http.request.header.{}", header_name);
             span.set_attribute(attribute_name, attribute_value.to_owned());
         }
@@ -248,7 +253,12 @@ fn record_response(span: &Span, kind: sealed::SpanKind, status: StatusCode, head
     span.record("http.response.status_code", status.as_u16() as i64);
 
     for (header_name, header_value) in headers.iter() {
-        if let Ok(attribute_value) = header_value.to_str() {
+        let attribute_value = if header_value.is_sensitive() {
+            Some("Sensitive")
+        } else {
+            header_value.to_str().ok()
+        };
+        if let Some(attribute_value) = attribute_value {
             let attribute_name = format!("http.response.header.{}", header_name);
             span.set_attribute(attribute_name, attribute_value.to_owned());
         }


### PR DESCRIPTION
By default, tower-otel records all request and response headers on the
OpenTelemetry span, except for values with non-visible or non-ASCII characters.

This commit replaces the values of headers marked as sensitive with
"Sensitive", just like HeaderValue's Debug fmt implementation.

The following examples shows how to mark sensitive headers using tower-http:

```rust
// Router applies layers from bottom to top.
// ServiceBuilder applies layers from top to bottom.
let app = axum::Router::new()
    .route(
	"/",
	axum::routing::get(|| async { ([("set-cookie", "foo=bar")], "Hello, world!") }),
    )
    .
    .layer(
	tower::ServiceBuilder::new()
	    .sensitive_request_headers(std::sync::Arc::new([
		axum::http::header::COOKIE,
		axum::http::header::AUTHORIZATION,
		axum::http::header::PROXY_AUTHORIZATION,
	    ]))
	    .layer(tower_otel::trace::HttpLayer::server(tracing::Level::INFO))
	    .sensitive_response_headers(std::sync::Arc::new([axum::http::header::SET_COOKIE]))
    );
```

Fixes #81.
